### PR TITLE
feat: ensure alt text for Markdown images

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,0 +1,8 @@
+{{- $src := .Destination | safeURL -}}
+{{- $alt := .Text | plainify -}}
+{{- if not $alt -}}
+  {{- $alt = path.Base $src -}}
+  {{- $ext := path.Ext $alt -}}
+  {{- $alt = strings.TrimSuffix $alt $ext -}}
+{{- end -}}
+<img src="{{ $src }}" alt="{{ $alt }}"{{ with .Title }} title="{{ . }}"{{ end }}{{ with .Attributes }} {{ . }}{{ end }} />


### PR DESCRIPTION
## Summary
- add custom image renderer that assigns alt text from the file name when none is provided

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b774b1fbd88330bafd2f02257240c3