### PR TITLE
feat: enable zoom on article images

### DIFF
--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -168,12 +168,14 @@ a.tag:focus-visible,
   object-fit: cover;
 }
 
+/* 記事本文内の画像設定（クリックで拡大対応） */
 .post-content img {
   max-width: 400px;   /* 横幅の上限 */
   width: 100%;        /* 画面サイズが400px以下なら縮小 */
   height: auto;       /* 縦横比を維持 */
   display: block;     /* インライン要素の隙間をなくす */
   margin: 1.5rem auto;/* 中央寄せ＆上下余白 */
+  cursor: zoom-in;    /* クリックでズーム可能であることを示す */
 }
 
 .social-icons a svg {

--- a/assets/css/extended/custom.css
+++ b/assets/css/extended/custom.css
@@ -178,6 +178,14 @@ a.tag:focus-visible,
   cursor: zoom-in;    /* クリックでズーム可能であることを示す */
 }
 
+/* ズーム時の背景色をテーマに合わせて調整 */
+.medium-zoom-overlay {
+  background: rgba(255, 255, 255, 0.8) !important; /* ライトモード */
+}
+.dark .medium-zoom-overlay {
+  background: rgba(0, 0, 0, 0.8) !important;       /* ダークモード */
+}
+
 .social-icons a svg {
   width: 40px;
   height: 40px;

--- a/layouts/partials/extend_footer.html
+++ b/layouts/partials/extend_footer.html
@@ -1,0 +1,8 @@
+<!-- ブログの記事画像をクリックすると拡大表示できるようにする -->
+<script defer src="https://cdn.jsdelivr.net/npm/medium-zoom@1.0.8/dist/medium-zoom.min.js"></script>
+<script defer>
+  document.addEventListener('DOMContentLoaded', () => {
+    // 記事本文内の画像にズーム機能を適用
+    mediumZoom('.post-content img');
+  });
+</script>


### PR DESCRIPTION
## Summary
- allow clicking blog images to zoom
- show zoom-in cursor for post images
- add Japanese comments for the zoom feature

## Testing
- `hugo --minify` *(fails: command not found: hugo)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be4d602f80833089e2ea9430736bd5