### PR TITLE
Enable accurate reading time for Japanese posts

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,5 +1,6 @@
 baseURL = "https://zipishi.com/"
 languageCode = "ja"
+hasCJKLanguage = true
 title = "ぢぴ氏の育児奮闘記"
 theme = "PaperMod"
 enableGitInfo = true


### PR DESCRIPTION
## Summary
- enable CJK mode in Hugo so that reading time uses Japanese character counts

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c50eac35bc8330a5b1a10bee513331