### PR TITLE
Use credentials tf var file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ node_modules/
 # --- Local environment files ---
 .env
 .env.*
+
+# --- Terraform credentials ---
+terraform/credentials.tf
+

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 詳しいドキュメントは [docs/README.md](docs/README.md) を参照してください。
 新しく参加する方は [プロジェクト構造や運用の基本](docs/CONTRIBUTING.md) を確認してください。
 
+Cloudflare Workers を使った定期ビルドの Terraform 構成については、[terraform/README.md](terraform/README.md) を参照してください。

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,69 @@
+# Cloudflare Workers による定期ビルド自動化 Terraform 構成
+
+このディレクトリには、Cloudflare Workers を用いて1時間ごとにビルド用Webhookを呼び出すための Terraform 構成が含まれています。Worker は Cron Triggers を利用して毎時0分に起動され、指定したWebhookへ `POST` リクエストを送信します。Webhookからのレスポンスはログとして返却されるため、Cloudflare Workers ダッシュボードや Wrangler CLI から実行結果を確認できます。
+
+## 前提条件
+
+- Terraform 1.3.0 以上
+- Cloudflare アカウントおよび Workers を利用できる有効なサブスクリプション
+- Workers のデプロイと Cron Triggers を設定できる権限を持つ API トークン
+- ビルドを実行するためのWebhook URL（例えばCIサービスのビルド用Webhook）
+
+## ファイル構成
+
+- `main.tf`: Cloudflare プロバイダー、Worker スクリプト、Cron Trigger の定義を行います。
+- `variables.tf`: Worker 名や資格情報など、Terraform が利用する変数を宣言します。
+- `credentials.tf.example`: 実際の資格情報を設定するためのサンプル値です。このファイルを `credentials.tf` にコピーして利用します（`credentials.tf` は Git で無視されます）。
+
+## 変数の設定
+
+Terraform 実行前に、以下の手順で資格情報を設定してください。
+
+1. `terraform/credentials.tf.example` を `terraform/credentials.tf` にコピーします。
+2. コピーした `credentials.tf` の各値を実環境の情報に置き換えます。
+
+`credentials.tf` は `.gitignore` に含まれており、誤ってリポジトリへコミットされることはありません。Terraform Cloud などのマネージド環境を利用する場合は、このファイルを作成せずに `terraform.tfvars` や `TF_VAR_` 環境変数で同じ変数名を指定しても構いません。
+
+設定が必要な値は次のとおりです。
+
+```hcl
+cloudflare_account_id = "cf-account-id"
+cloudflare_api_token  = "cf-api-token"
+# 任意: Worker 名を変更したい場合
+# worker_name = "custom-worker-name"
+# 任意: ビルド用WebhookのURLを設定
+# build_webhook_url = "https://example.com/build"
+```
+
+`build_webhook_url` を設定すると、Worker が毎時このURLに `POST` リクエストを送信します。Terraform の状態ファイルにWebhook URLを平文で保持したくない場合は、`credentials.tf` を使用せずに Terraform Cloud/Enterprise の変数管理や `TF_VAR_build_webhook_url` として環境変数を利用してください。
+
+## デプロイ手順
+
+1. Terraform の初期化:
+   ```bash
+   terraform init
+   ```
+2. 適用前の差分確認:
+   ```bash
+   terraform plan -var-file=credentials.tf
+   ```
+3. リソースの作成:
+   ```bash
+   terraform apply -var-file=credentials.tf
+   ```
+
+適用後、Cloudflare ダッシュボードの Workers セクションに Worker が追加され、Cron Trigger が 1 時間ごとに実行されます。手動で動作確認したい場合は、Worker の「テスト」から `fetch` ハンドラーを実行すると同じ処理を確認できます。
+
+## スケジュールの変更
+
+`cloudflare_worker_cron_trigger.hourly` リソースの `schedules` を変更することで、実行タイミングを自由に調整できます。Cron 式は [Cloudflare Workers Cron Triggers の仕様](https://developers.cloudflare.com/workers/platform/triggers/cron-triggers/) に従います。
+
+## クリーンアップ
+
+作成したリソースを削除するには、以下を実行してください。
+
+```bash
+terraform destroy
+```
+
+これにより、Worker スクリプトと Cron Trigger が Cloudflare から削除されます。

--- a/terraform/credentials.tf.example
+++ b/terraform/credentials.tf.example
@@ -1,0 +1,12 @@
+# Cloudflareのアカウント情報とビルド用Webhookの設定値を記載します。
+# このファイルを `credentials.tf` にコピーし、実環境の値へ書き換えてください。
+# `credentials.tf` は Git で無視されるため、誤ってコミットされることはありません。
+
+cloudflare_account_id = "cf-account-id"
+cloudflare_api_token  = "cf-api-token"
+# Worker名を変更したい場合は、`variables.tf` の `worker_name` 変数を上書きするか
+# 以下のコメントアウトを外して値を設定してください。
+# worker_name = "hourly-build-worker"
+
+# ビルドを実行するWebhookのURLを指定します。HTTP POST が送信されます。
+build_webhook_url = "https://example.com/build"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,78 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = ">= 4.0"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}
+
+locals {
+  worker_script = <<'JS'
+export default {
+  async scheduled(event, env, ctx) {
+    ctx.waitUntil(triggerBuild(env));
+  },
+
+  async fetch(request, env) {
+    return triggerBuild(env);
+  },
+};
+
+async function triggerBuild(env) {
+  if (!env.BUILD_WEBHOOK_URL) {
+    return new Response(JSON.stringify({
+      ok: false,
+      message: "BUILD_WEBHOOK_URL is not configured.",
+    }), {
+      status: 500,
+      headers: {
+        "content-type": "application/json",
+      },
+    });
+  }
+
+  const response = await fetch(env.BUILD_WEBHOOK_URL, {
+    method: "POST",
+  });
+
+  const body = await response.text();
+
+  return new Response(JSON.stringify({
+    ok: response.ok,
+    status: response.status,
+    statusText: response.statusText,
+    body,
+  }), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+JS
+}
+
+resource "cloudflare_worker_script" "hourly_build" {
+  account_id = var.cloudflare_account_id
+  name       = var.worker_name
+  module     = true
+  content    = local.worker_script
+
+  plain_text_binding {
+    name = "BUILD_WEBHOOK_URL"
+    text = var.build_webhook_url
+  }
+}
+
+resource "cloudflare_worker_cron_trigger" "hourly" {
+  account_id = var.cloudflare_account_id
+  script_name = cloudflare_worker_script.hourly_build.name
+  schedules   = ["0 * * * *"]
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,26 @@
+# Terraformで使用する変数を定義します。公開しても問題のない設定値と、資格情報を含む値をまとめて宣言しています。
+# 実際の値は `credentials.tf` や `TF_VAR_` 環境変数などから与えてください。
+
+variable "cloudflare_account_id" {
+  type        = string
+  description = "CloudflareのアカウントID。"
+}
+
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Workersをデプロイできる権限を持つCloudflareのAPIトークン。"
+  sensitive   = true
+}
+
+variable "build_webhook_url" {
+  type        = string
+  description = "ビルド処理を起動するWebhookのURL。"
+  sensitive   = true
+  nullable    = false
+}
+
+variable "worker_name" {
+  type        = string
+  description = "作成するWorkerスクリプトの名前。"
+  default     = "hourly-build-worker"
+}


### PR DESCRIPTION
## Summary
- Terraformの資格情報サンプルを `credentials.tf.example` に改名し、ローカルで編集する `credentials.tf` を `.gitignore` で除外しました
- Terraform README を更新し、`credentials.tf` のコピー手順と `-var-file=credentials.tf` を使った実行方法を追記しました
- 変数定義ファイル内のコメントを `credentials.tf` 利用前提の説明へ修正しました

## Testing
- not run (Terraform CLI が環境に存在しないため実行不可)


------
https://chatgpt.com/codex/tasks/task_e_68ce03c3365c83308a2129db3813e331