### PR TITLE
未使用パーシャルの削除とタグの記法ミス修正

### DIFF
--- a/content/posts/251007-tokyo1.md
+++ b/content/posts/251007-tokyo1.md
@@ -8,7 +8,7 @@ cover:
   hiddenInSingle: true
 date: 2025-10-07T21:30:00+09:00
 lastmod: 2025-10-07T21:30:00+09:00
-tags: ["育児", 1歳", "旅行", "新幹線"]
+tags: ["育児", "1歳", "旅行", "新幹線"]
 categories: ["日記"]
 Author: "ぢぴ氏"
 draft: false

--- a/layouts/partials/extend_body.html
+++ b/layouts/partials/extend_body.html
@@ -1,4 +1,0 @@
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PVSRD6WX"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->

--- a/layouts/partials/extend_head.html
+++ b/layouts/partials/extend_head.html
@@ -1,3 +1,5 @@
+<!-- Google Search Console 所有権確認 -->
+<meta name="google-site-verification" content="azPAV01RltK2oJ-OtZ1KljlwJ930G8Qr1o_fufJ5hEM" />
 <!-- Google Tag Manager -->
 <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],


### PR DESCRIPTION
Search Console の所有権確認（GTM 方式）が失敗した原因を調査する過程で、既存のバグを2件発見したので修正します。

## 1. `extend_body.html` は一度も出力されていなかった

PaperMod が提供するフックは2つだけです。

```
themes/PaperMod/layouts/partials/head.html:149   → extend_head.html
themes/PaperMod/layouts/partials/footer.html:33  → extend_footer.html
```

`extend_body.html` というフックは存在せず、このファイルはどのテンプレートからも呼ばれていませんでした（2025年10月の初期構築時から）。そのため GTM の `<noscript>` スニペットは一度も HTML に出力されていません。

デプロイ済み HTML での実測:

| 要素 | 位置 |
|---|---|
| GTM の JS スニペット | head 内にあり ✅ |
| GTM の noscript スニペット | **存在しない ❌** |

GA4 の計測自体は head 側のスニペットで正常に動作しています（実ブラウザで `g/collect` の 204 応答を確認済み）。noscript は JS 無効ユーザー向けなので実害はありませんが、Search Console の GTM 認証がこの noscript を探すため失敗します。

死んだファイルなので削除します。Search Console の認証は HTML タグ方式に切り替えます。

## 2. `251007-tokyo1.md` のタグに開き引用符が抜けていた

```diff
-tags: ["育児", 1歳", "旅行", "新幹線"]
+tags: ["育児", "1歳", "旅行", "新幹線"]
```

`1歳"` という不正なタグが生成され、正規の `1歳` タグと**同じ出力パス** `tags/1歳/` に衝突していました。結果、どちらが出力されるかがビルドごとに変わる**非決定的な状態**になっていました。

### 検証

```
【修正前】同一ツリーで2回ビルド
  → tags/1歳/index.html に差分あり（非決定的）

【修正後】同一ツリーで2回ビルド
  → 完全一致 ✅

Pages: 135 → 133（重複していたタグページが解消）
1歳 タグページ: 251007-tokyo1 が正しく含まれるようになり 10記事
不正タグ `1歳"` の残骸: 0件
```

修正前は、この記事が `1歳` タグの一覧から漏れている状態でした。

## 影響範囲

タグディレクトリの総数は前後とも 40 で変化なし。他のページへの影響はありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)