### PR TITLE
アーカイブページの front matter 破損を修正

### DIFF
--- a/content/archives/_index.md
+++ b/content/archives/_index.md
@@ -1,4 +1,3 @@
-# content/archives/_index.md
 ---
 title: "アーカイブ"
 layout: "archives"


### PR DESCRIPTION
## 背景

Search Console から以下の通知メールが届きました。

> `https://zipishi-blog.pages.dev/` で新しいパンくずリストの構造化データの問題が検出されました
> 「name」または「item.name」のどちらかを指定してください（「itemListElement」に含まれる）

## 原因

`content/archives/_index.md` の1行目に `# content/archives/_index.md` という余計な行が front matter の `---` より前に混入していました。

```diff
-# content/archives/_index.md
 ---
 title: "アーカイブ"
 layout: "archives"
 url: "/archives/"
 ---
```

front matter は**ファイル先頭バイトから** `---` で始まっていないと Hugo に認識されません。この行があったせいで `title: "アーカイブ"` が読み込まれず、このページの `.Title` / `.Name` が空文字になっていました。

## 影響していたもの

- `<title>` タグ: 本来「アーカイブ | ぢぴ氏の育児奮闘記」のはずが、サイト名のみになっていた
- `BreadcrumbList` 構造化データ: `"name": ""` となり、Search Console のエラー原因に

## 検証

修正前後でビルドし、全ページの `BreadcrumbList` JSON-LD をスキャンして確認しました。

```
【修正前】BreadcrumbList総数: 43 / 問題件数: 1（archives のみ）
【修正後】BreadcrumbList総数: 43 / 問題件数: 0

<title> タグ: 「アーカイブ | ぢぴ氏の育児奮闘記」に復旧
```

同様の混入が他の content ファイルにないかも全走査済み（該当なし、archives のみの単発事象）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)